### PR TITLE
支持IPv6和域名 

### DIFF
--- a/MOTDAPI/MOTDAPI.csproj
+++ b/MOTDAPI/MOTDAPI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/MOTDAPI/Main.cs
+++ b/MOTDAPI/Main.cs
@@ -1,7 +1,9 @@
-﻿using LLNET.Core;
-using LLNET.Logger;
+﻿using LiteLoader.Logger;
+using LiteLoader.NET;
+using LiteLoader.RemoteCall;
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Sockets;
 using System.Text;
 
@@ -16,12 +18,16 @@ public class Main : IPluginInitializer
     public void OnInitialize()
     {
         Logger logger = new("MOTDAPI");
-        _ = LLNET.RemoteCall.RemoteCallAPI.ExportAs("MOTDAPI", "GetFromBE", (string ip, ushort port) =>
+        _ = RemoteCallAPI.ExportAs("MOTDAPI", "GetFromBE", (string addr, ushort port) =>
         {
-            Socket socket = new(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
             byte[] back = new byte[256];
             try
             {
+                if (!(IPAddress.TryParse(addr, out IPAddress ip) && ip != null)) // 无法直接转换的ip尝试使用dns解析
+                {
+                    ip = Dns.GetHostAddresses(addr)[0];
+                }
+                Socket socket = new(ip.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
                 socket.Connect(ip, port);
                 _ = socket.Send(data);
                 _ = socket.Receive(back);


### PR DESCRIPTION
### 更改内容

- 支持IPv6 *
- 支持域名解析
- 修复无法编译

 ##### * 测试结果

- [ ] IPv6
  - 总是报错`System.Net.Sockets.SocketException (0x80004005): 系统检测到在一个调用中尝试使用指针参数时的无效指针地址。`，应该是系统问题，暂时没找到合适的解决方案
  - 代码应该没问题（吧？
- [x] IPv4
- [x] 域名解析